### PR TITLE
ディレクトリ操作系のsnippet追加

### DIFF
--- a/.snippets
+++ b/.snippets
@@ -39,6 +39,9 @@ ll                     # ls -lFh
 lla                    # ls ls -alh
 ls                     # ls --color=auto
 cls                    # clear && ls -F
+ln -nfs                # overwrite symbolic link
+tree -h                # show directory tree & file size
+tree -pug              # show directory tree & permission, user
 
 # make
 m                      # make


### PR DESCRIPTION
- 上書きシンボリックリンク `ln -s`
- `tree` のサイズ/パーミッション/所有者の表示